### PR TITLE
#164 Fixed NPE for Activity Explorer in Custom perspective

### DIFF
--- a/plugins/org.eclipse.amalgam.explorer.activity.ui/src/org/eclipse/amalgam/explorer/activity/ui/api/editor/ActivityExplorerEditor.java
+++ b/plugins/org.eclipse.amalgam.explorer.activity.ui/src/org/eclipse/amalgam/explorer/activity/ui/api/editor/ActivityExplorerEditor.java
@@ -145,8 +145,10 @@ public class ActivityExplorerEditor extends SharedHeaderFormEditor implements IT
 
             public void controlResized(ControlEvent cevent) {
                 IFormPage activePageInstance = ActivityExplorerEditor.this.getActivePageInstance();
-                IManagedForm managedForm = activePageInstance.getManagedForm();
-                managedForm.reflow(true);
+                if(activePageInstance != null) {
+                    IManagedForm managedForm = activePageInstance.getManagedForm();
+                    managedForm.reflow(true);
+                }               
             }
         });
         // Refresh dirty state when the part is activated : open time for
@@ -313,7 +315,9 @@ public class ActivityExplorerEditor extends SharedHeaderFormEditor implements IT
                     }
                 }
                 // Call remove page
-                removePage(pageIndex);
+                if(pages.size() != 0) {
+                	removePage(pageIndex);
+                }                
             }
 
             // Add new message page if not null


### PR DESCRIPTION
Fixed issue where Capella would crash when activity explorer is opened on a connected project in a custom perspective

Change-Id: Ibed50439c1d8166f8c693d00e481a5a860fe4a32